### PR TITLE
Add monitoring dashboard and multi-token support with Docker setup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM denoland/deno:alpine-1.46.3
+
+WORKDIR /app
+
+COPY . .
+
+RUN deno cache main.ts
+
+EXPOSE 8080
+
+CMD ["deno", "run", "--allow-env", "--allow-net", "--allow-read", "main.ts"]

--- a/README.md
+++ b/README.md
@@ -81,10 +81,24 @@ console.log(response.choices[0].message.content);
 
 ### Docker 部署
 
+使用仓库根目录提供的 `Dockerfile` 可以快速构建镜像：
+
 ```bash
-cd deploy
-docker-compose up -d
+docker build -t zai2api .
+docker run --name zai2api -p 8080:8080 \
+  -e AUTH_TOKEN=your-auth-token \
+  -e BACKUP_TOKEN="token1,token2" \
+  zai2api
 ```
+
+> 仍可使用 `deploy` 目录中的示例 `docker-compose.yml` 进行编排部署。
+
+### 监控面板
+
+- 访问 `http://<host>:8080/dashboard` 打开监控控制台，登录密码与 `AUTH_TOKEN` 相同。
+- 实时查看总请求数、成功/失败统计与平均响应时间，支持自动刷新或手动刷新。
+- 最近 100 条请求详细信息（时间、方法、路径、状态、耗时、客户端 IP、使用的 Token）一目了然。
+- 在 Backup Token 管理界面中可以查看每个 Token 的成功/失败次数，并可在线添加或删除，立即生效。
 
 ## 📖 详细指南
 

--- a/app/core/metrics.ts
+++ b/app/core/metrics.ts
@@ -1,0 +1,77 @@
+import { formatTokenDisplay, TokenSource } from "./token_manager.ts";
+
+export interface RequestLogEntry {
+  timestamp: number;
+  method: string;
+  path: string;
+  status: number;
+  durationMs: number;
+  success: boolean;
+  clientIp: string;
+  tokenDisplay: string;
+  tokenSource: TokenSource | "none";
+}
+
+export interface MetricsSummary {
+  totalRequests: number;
+  successfulRequests: number;
+  failedRequests: number;
+  averageResponseTime: number;
+}
+
+class MetricsManager {
+  private totalRequests = 0;
+  private successfulRequests = 0;
+  private failedRequests = 0;
+  private totalResponseTime = 0;
+  private readonly recentRequests: RequestLogEntry[] = [];
+  private readonly maxRecent = 100;
+
+  recordRequest(entry: Omit<RequestLogEntry, "tokenDisplay"> & { token: string; tokenSource: TokenSource | "none" }): void {
+    const tokenDisplay = entry.tokenSource === "none"
+      ? "-"
+      : formatTokenDisplay(entry.token, entry.tokenSource === "none" ? "backup" : entry.tokenSource);
+
+    const logEntry: RequestLogEntry = {
+      timestamp: entry.timestamp,
+      method: entry.method,
+      path: entry.path,
+      status: entry.status,
+      durationMs: entry.durationMs,
+      success: entry.success,
+      clientIp: entry.clientIp,
+      tokenDisplay,
+      tokenSource: entry.tokenSource,
+    };
+
+    this.totalRequests += 1;
+    if (entry.success) {
+      this.successfulRequests += 1;
+    } else {
+      this.failedRequests += 1;
+    }
+    this.totalResponseTime += entry.durationMs;
+
+    this.recentRequests.unshift(logEntry);
+    if (this.recentRequests.length > this.maxRecent) {
+      this.recentRequests.pop();
+    }
+  }
+
+  getSummary(): MetricsSummary {
+    return {
+      totalRequests: this.totalRequests,
+      successfulRequests: this.successfulRequests,
+      failedRequests: this.failedRequests,
+      averageResponseTime: this.totalRequests === 0
+        ? 0
+        : Number((this.totalResponseTime / this.totalRequests).toFixed(2)),
+    };
+  }
+
+  getRecentRequests(): RequestLogEntry[] {
+    return [...this.recentRequests];
+  }
+}
+
+export const metricsManager = new MetricsManager();

--- a/app/core/openai.ts
+++ b/app/core/openai.ts
@@ -12,6 +12,8 @@ import { debugLog, generateRequestIds, getAuthToken } from "../utils/helpers.ts"
 import { processMessagesWithTools, contentToString } from "../utils/tools.ts";
 import { StreamResponseHandler, NonStreamResponseHandler } from "./response_handlers.ts";
 import { getAvailableModels } from "../utils/model_fetcher.ts";
+import { metricsManager } from "./metrics.ts";
+import { backupTokenManager } from "./token_manager.ts";
 
 export const openaiRouter = new Router();
 
@@ -91,61 +93,94 @@ openaiRouter.get("/models", async (ctx) => {
 openaiRouter.post("/chat/completions", async (ctx) => {
   /**Handle chat completion requests*/
   debugLog("收到chat completions请求");
-  
+
+  const requestStart = performance.now();
+  const clientIp = ctx.request.ip ||
+    ctx.request.headers.get("x-forwarded-for") ||
+    ctx.request.headers.get("x-real-ip") ||
+    "unknown";
+  let tokenInfo: Awaited<ReturnType<typeof getAuthToken>> | null = null;
+  let metricsRecorded = false;
+
+  const finalizeMetrics = (status: number, success: boolean) => {
+    if (metricsRecorded) {
+      return;
+    }
+    metricsRecorded = true;
+    const duration = Number((performance.now() - requestStart).toFixed(2));
+    metricsManager.recordRequest({
+      timestamp: Date.now(),
+      method: ctx.request.method,
+      path: ctx.request.url.pathname,
+      status,
+      durationMs: duration,
+      success,
+      clientIp,
+      token: tokenInfo?.token ?? "",
+      tokenSource: tokenInfo?.source ?? "none",
+    });
+
+    if (tokenInfo?.source === "backup") {
+      backupTokenManager.recordResult(tokenInfo.token, success);
+    }
+  };
+
   try {
     // Get authorization header
     const authorization = ctx.request.headers.get("authorization");
-    
+
     // Validate API key (skip if SKIP_AUTH_TOKEN is enabled)
     if (!config.SKIP_AUTH_TOKEN) {
       if (!authorization || !authorization.startsWith("Bearer ")) {
         debugLog("缺少或无效的Authorization头");
         ctx.response.status = 401;
         ctx.response.body = { error: "Missing or invalid Authorization header" };
+        finalizeMetrics(401, false);
         return;
       }
-      
+
       const apiKey = authorization.substring(7);
       if (apiKey !== config.AUTH_TOKEN) {
         debugLog(`无效的API key: ${apiKey}`);
         ctx.response.status = 401;
         ctx.response.body = { error: "Invalid API key" };
+        finalizeMetrics(401, false);
         return;
       }
-      
+
       debugLog(`API key验证通过，AUTH_TOKEN=${apiKey.substring(0, 8)}......`);
     } else {
       debugLog("SKIP_AUTH_TOKEN已启用，跳过API key验证");
     }
-    
+
     // Parse and validate request body
     const requestBody = await ctx.request.body().value;
     const request = OpenAIRequestSchema.parse(requestBody);
-    
+
     debugLog(`请求解析成功 - 模型: ${request.model}, 流式: ${request.stream}, 消息数: ${request.messages.length}`);
-    
+
     // Generate IDs
     const [chatId, msgId] = generateRequestIds();
-    
+
     // Process messages with tools
     const processedMessages = processMessagesWithTools(
       request.messages.map(m => ({ ...m })),
       request.tools,
       request.tool_choice
     );
-    
+
     // Convert back to Message objects
     const upstreamMessages: Message[] = [];
     for (const msg of processedMessages) {
       const content = contentToString(msg.content);
-      
+
       upstreamMessages.push({
         role: msg.role,
         content: content,
         reasoning_content: msg.reasoning_content
       });
     }
-    
+
     // Determine model features
     const isThinking = request.model === config.THINKING_MODEL;
     const isSearch = request.model === config.SEARCH_MODEL;
@@ -153,7 +188,7 @@ openaiRouter.post("/chat/completions", async (ctx) => {
     const isNewThinking = request.model === config.THINKING_MODEL_NEW;
     const isNewSearch = request.model === config.SEARCH_MODEL_NEW;
     const searchMcp = isSearch || isNewSearch ? "deep-web-search" : "";
-    
+
     // Determine upstream model ID based on requested model
     let upstreamModelId: string;
     let upstreamModelName: string;
@@ -173,7 +208,7 @@ openaiRouter.post("/chat/completions", async (ctx) => {
       upstreamModelId = "0727-360B-API"; // Default upstream model ID
       upstreamModelName = "GLM-4.5";
     }
-    
+
     // Build upstream request
     const upstreamReq: UpstreamRequest = {
       stream: true, // Always use streaming from upstream
@@ -204,32 +239,46 @@ openaiRouter.post("/chat/completions", async (ctx) => {
         "{{CURRENT_DATETIME}}": new Date().toISOString().replace('T', ' ').substring(0, 19),
       }
     };
-    
+
     // Get authentication token
-    const authToken = await getAuthToken();
-    
+    tokenInfo = await getAuthToken();
+    const authToken = tokenInfo.token;
+
     // Check if tools are enabled and present
-    const hasTools = (config.TOOL_SUPPORT && 
-                    request.tools && 
-                    request.tools.length > 0 && 
+    const hasTools = (config.TOOL_SUPPORT &&
+                    request.tools &&
+                    request.tools.length > 0 &&
                     request.tool_choice !== "none");
-    
+
     // Handle response based on stream flag
     if (request.stream) {
-      const handler = new StreamResponseHandler(upstreamReq, chatId, authToken, hasTools);
-      
+      const handler = new StreamResponseHandler(
+        upstreamReq,
+        chatId,
+        authToken,
+        hasTools,
+        (result) => {
+          if (!result.success) {
+            finalizeMetrics(result.status, false);
+          }
+        },
+      );
+
       // Set SSE headers
       ctx.response.headers.set("Content-Type", "text/event-stream");
       ctx.response.headers.set("Cache-Control", "no-cache");
       ctx.response.headers.set("Connection", "keep-alive");
       ctx.response.headers.set("Access-Control-Allow-Origin", "*");
-      
+
       // Create a readable stream with better error handling
       const stream = new ReadableStream({
         async start(controller) {
           try {
             for await (const chunk of handler.handle()) {
               controller.enqueue(new TextEncoder().encode(chunk));
+            }
+            if (!metricsRecorded) {
+              finalizeMetrics(200, true);
             }
             controller.close();
           } catch (error) {
@@ -242,40 +291,58 @@ openaiRouter.post("/chat/completions", async (ctx) => {
             } catch (controllerError) {
               debugLog(`控制器错误: ${controllerError}`);
             }
+            finalizeMetrics(500, false);
             controller.close();
           }
         },
         cancel() {
           debugLog("客户端取消了流式响应");
+          finalizeMetrics(499, false);
         }
       });
-      
+
       ctx.response.body = stream;
     } else {
       try {
-        const handler = new NonStreamResponseHandler(upstreamReq, chatId, authToken, hasTools);
+        const handler = new NonStreamResponseHandler(
+          upstreamReq,
+          chatId,
+          authToken,
+          hasTools,
+          (result) => {
+            if (!result.success) {
+              finalizeMetrics(result.status, false);
+            }
+          },
+        );
         const response = await handler.handle();
-        
+
         // Copy response properties
         ctx.response.status = response.status;
         ctx.response.headers = response.headers;
         ctx.response.body = await response.text();
+        if (!metricsRecorded) {
+          finalizeMetrics(response.status, response.ok);
+        }
       } catch (nonStreamError) {
         debugLog(`非流式响应处理错误: ${nonStreamError}`);
         ctx.response.status = 500;
         ctx.response.body = { error: `Non-stream processing error: ${nonStreamError}` };
+        finalizeMetrics(500, false);
       }
     }
-        
+
   } catch (error) {
     debugLog(`外层请求处理错误: ${error}`);
     console.error("Error stack:", error);
-    
+
     // 只有在响应还没有开始时才设置错误响应
     if (!ctx.response.body) {
       ctx.response.status = 500;
       ctx.response.body = { error: `Internal server error: ${error}` };
-    } else {
+      finalizeMetrics(ctx.response.status ?? 500, false);
+    } else if (!metricsRecorded) {
+      finalizeMetrics(ctx.response.status ?? 500, false);
       debugLog("响应已开始，无法设置错误状态");
     }
   }

--- a/app/core/token_manager.ts
+++ b/app/core/token_manager.ts
@@ -1,0 +1,148 @@
+import { config } from "./config.ts";
+
+export type TokenSource = "anonymous" | "backup";
+
+export interface AuthTokenInfo {
+  token: string;
+  source: TokenSource;
+  displayToken: string;
+}
+
+interface TokenStats {
+  success: number;
+  failure: number;
+}
+
+export interface BackupTokenStatus {
+  token: string;
+  success: number;
+  failure: number;
+}
+
+function normalizeToken(token: string): string {
+  return token.trim();
+}
+
+function maskToken(token: string): string {
+  if (token.length <= 10) {
+    return token;
+  }
+  return `${token.slice(0, 4)}...${token.slice(-4)}`;
+}
+
+class BackupTokenManager {
+  private tokens: string[] = [];
+  private currentIndex = 0;
+  private readonly stats: Map<string, TokenStats> = new Map();
+
+  constructor(initialTokens: string) {
+    this.setTokensFromString(initialTokens);
+  }
+
+  private updateConfigValue(): void {
+    config.BACKUP_TOKEN = this.tokens.join(",");
+  }
+
+  private ensureStats(token: string): void {
+    if (!this.stats.has(token)) {
+      this.stats.set(token, { success: 0, failure: 0 });
+    }
+  }
+
+  setTokensFromString(tokenString: string): void {
+    const parsedTokens = tokenString
+      .split(",")
+      .map(normalizeToken)
+      .filter(token => token.length > 0);
+
+    this.tokens = parsedTokens;
+    this.currentIndex = 0;
+
+    for (const token of parsedTokens) {
+      this.ensureStats(token);
+    }
+
+    this.updateConfigValue();
+  }
+
+  getTokens(): string[] {
+    return [...this.tokens];
+  }
+
+  addToken(token: string): boolean {
+    const normalized = normalizeToken(token);
+    if (!normalized || this.tokens.includes(normalized)) {
+      return false;
+    }
+    this.tokens.push(normalized);
+    this.ensureStats(normalized);
+    this.updateConfigValue();
+    return true;
+  }
+
+  removeToken(token: string): boolean {
+    const normalized = normalizeToken(token);
+    const index = this.tokens.indexOf(normalized);
+    if (index === -1) {
+      return false;
+    }
+
+    this.tokens.splice(index, 1);
+
+    if (this.tokens.length === 0) {
+      this.currentIndex = 0;
+    } else if (index <= this.currentIndex && this.currentIndex > 0) {
+      this.currentIndex = (this.currentIndex - 1) % this.tokens.length;
+    }
+
+    this.stats.delete(normalized);
+    this.updateConfigValue();
+    return true;
+  }
+
+  getNextToken(): string | null {
+    if (this.tokens.length === 0) {
+      return null;
+    }
+
+    const token = this.tokens[this.currentIndex];
+    this.currentIndex = (this.currentIndex + 1) % this.tokens.length;
+    return token;
+  }
+
+  recordResult(token: string, success: boolean): void {
+    const stats = this.stats.get(token);
+    if (!stats) {
+      return;
+    }
+    if (success) {
+      stats.success += 1;
+    } else {
+      stats.failure += 1;
+    }
+  }
+
+  getStatus(): BackupTokenStatus[] {
+    return this.tokens.map(token => {
+      const stats = this.stats.get(token) ?? { success: 0, failure: 0 };
+      return {
+        token,
+        success: stats.success,
+        failure: stats.failure,
+      };
+    });
+  }
+
+  getMaskedToken(token: string): string {
+    return maskToken(token);
+  }
+}
+
+export const backupTokenManager = new BackupTokenManager(config.BACKUP_TOKEN);
+
+export function formatTokenDisplay(token: string, source: TokenSource): string {
+  if (source === "anonymous") {
+    return token;
+  }
+  return maskToken(token);
+}

--- a/app/dashboard/router.ts
+++ b/app/dashboard/router.ts
@@ -1,0 +1,638 @@
+import { Router, Context } from "oak/mod.ts";
+import { config } from "../core/config.ts";
+import { metricsManager } from "../core/metrics.ts";
+import { backupTokenManager } from "../core/token_manager.ts";
+
+const SESSION_COOKIE = "dashboard_session";
+const SESSION_DURATION = 24 * 60 * 60 * 1000; // 24 hours
+const sessions = new Map<string, number>();
+
+function cleanupSessions(): void {
+  const now = Date.now();
+  for (const [sessionId, expiry] of sessions.entries()) {
+    if (expiry <= now) {
+      sessions.delete(sessionId);
+    }
+  }
+}
+
+async function getSessionId(ctx: Context): Promise<string | null> {
+  cleanupSessions();
+  const sessionId = await ctx.cookies.get(SESSION_COOKIE);
+  if (!sessionId) {
+    return null;
+  }
+  const expiry = sessions.get(sessionId);
+  if (!expiry || expiry <= Date.now()) {
+    sessions.delete(sessionId);
+    return null;
+  }
+  return sessionId;
+}
+
+async function ensureSession(ctx: Context): Promise<boolean> {
+  const sessionId = await getSessionId(ctx);
+  if (!sessionId) {
+    return false;
+  }
+  const nextExpiry = Date.now() + SESSION_DURATION;
+  sessions.set(sessionId, nextExpiry);
+  await ctx.cookies.set(SESSION_COOKIE, sessionId, {
+    httpOnly: true,
+    sameSite: "Strict",
+    maxAge: SESSION_DURATION / 1000,
+  });
+  return true;
+}
+
+function createSession(): string {
+  const sessionId = crypto.randomUUID();
+  sessions.set(sessionId, Date.now() + SESSION_DURATION);
+  return sessionId;
+}
+
+function renderLoginPage(errorMessage = ""): string {
+  const errorSection = errorMessage
+    ? `<p class="error">${errorMessage}</p>`
+    : "";
+  return `<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+  <meta charset="utf-8" />
+  <title>Dashboard 登录</title>
+  <style>
+    body { font-family: 'Segoe UI', Arial, sans-serif; background: #f3f4f6; display: flex; align-items: center; justify-content: center; height: 100vh; margin: 0; }
+    .login-card { background: white; padding: 32px; border-radius: 16px; box-shadow: 0 20px 45px rgba(15, 23, 42, 0.15); width: 360px; }
+    h1 { margin: 0 0 24px; font-size: 24px; color: #111827; text-align: center; }
+    label { display: block; margin-bottom: 8px; color: #374151; font-weight: 600; }
+    input[type="password"] { width: 100%; padding: 12px 14px; border: 1px solid #d1d5db; border-radius: 10px; font-size: 16px; transition: border-color 0.2s, box-shadow 0.2s; }
+    input[type="password"]:focus { outline: none; border-color: #6366f1; box-shadow: 0 0 0 3px rgba(99, 102, 241, 0.2); }
+    button { margin-top: 16px; width: 100%; padding: 12px; border: none; border-radius: 10px; background: linear-gradient(135deg, #6366f1, #8b5cf6); color: white; font-size: 16px; font-weight: 600; cursor: pointer; transition: transform 0.2s, box-shadow 0.2s; }
+    button:hover { transform: translateY(-1px); box-shadow: 0 15px 30px rgba(99, 102, 241, 0.3); }
+    .error { margin-top: 16px; color: #ef4444; text-align: center; }
+  </style>
+</head>
+<body>
+  <div class="login-card">
+    <h1>管理面板登录</h1>
+    ${errorSection}
+    <form method="post" action="/dashboard/login">
+      <label for="password">访问密码</label>
+      <input type="password" id="password" name="password" placeholder="请输入AUTH_TOKEN" required />
+      <button type="submit">登录</button>
+    </form>
+  </div>
+</body>
+</html>`;
+}
+
+const dashboardPage = `<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+  <meta charset="utf-8" />
+  <title>API 监控面板</title>
+  <style>
+    :root {
+      color-scheme: light dark;
+    }
+    body {
+      font-family: 'Segoe UI', Arial, sans-serif;
+      background: #0f172a;
+      color: #e2e8f0;
+      margin: 0;
+      padding: 24px;
+    }
+    h1 {
+      margin: 0;
+      font-size: 28px;
+    }
+    .grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+      gap: 16px;
+      margin-top: 24px;
+    }
+    .card {
+      background: rgba(30, 41, 59, 0.85);
+      border-radius: 16px;
+      padding: 20px;
+      box-shadow: 0 10px 30px rgba(15, 23, 42, 0.6);
+      backdrop-filter: blur(12px);
+    }
+    .card h2 {
+      margin: 0 0 12px;
+      font-size: 18px;
+      color: #cbd5f5;
+    }
+    .stat {
+      font-size: 32px;
+      font-weight: 700;
+      margin-bottom: 4px;
+    }
+    .stat-label {
+      color: #94a3b8;
+      font-size: 14px;
+    }
+    table {
+      width: 100%;
+      border-collapse: collapse;
+      margin-top: 12px;
+      font-size: 14px;
+    }
+    th, td {
+      padding: 8px 10px;
+      border-bottom: 1px solid rgba(148, 163, 184, 0.2);
+      text-align: left;
+    }
+    th {
+      color: #cbd5f5;
+      font-weight: 600;
+      background: rgba(30, 41, 59, 0.6);
+    }
+    tbody tr:hover {
+      background: rgba(59, 130, 246, 0.12);
+    }
+    .status-success {
+      color: #34d399;
+    }
+    .status-failure {
+      color: #f87171;
+    }
+    .controls {
+      display: flex;
+      flex-wrap: wrap;
+      align-items: center;
+      gap: 12px;
+      margin-top: 16px;
+    }
+    .toggle {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      font-size: 14px;
+    }
+    .tag {
+      display: inline-flex;
+      align-items: center;
+      gap: 6px;
+      padding: 4px 10px;
+      border-radius: 999px;
+      font-size: 13px;
+      background: rgba(148, 163, 184, 0.2);
+      color: #e2e8f0;
+    }
+    input[type="checkbox"] {
+      width: 18px;
+      height: 18px;
+    }
+    button.primary {
+      background: linear-gradient(135deg, #6366f1, #8b5cf6);
+      border: none;
+      color: white;
+      padding: 8px 14px;
+      border-radius: 999px;
+      cursor: pointer;
+      font-weight: 600;
+    }
+    button.secondary {
+      background: transparent;
+      border: 1px solid rgba(148, 163, 184, 0.4);
+      color: #e2e8f0;
+      padding: 8px 14px;
+      border-radius: 999px;
+      cursor: pointer;
+    }
+    .token-form {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 8px;
+      margin-top: 12px;
+    }
+    .token-form input {
+      flex: 1 1 240px;
+      padding: 10px 12px;
+      border-radius: 10px;
+      border: 1px solid rgba(148, 163, 184, 0.3);
+      background: rgba(15, 23, 42, 0.6);
+      color: #f8fafc;
+    }
+    .message {
+      margin-top: 12px;
+      font-size: 14px;
+    }
+    .message.error { color: #f87171; }
+    .message.success { color: #34d399; }
+    .message.warning { color: #fbbf24; }
+    .section-title {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      gap: 12px;
+    }
+    .token-table-wrapper {
+      overflow-x: auto;
+    }
+  </style>
+</head>
+<body>
+  <header>
+    <h1>API 监控面板</h1>
+    <div class="controls">
+      <span class="tag">匿名模式: <strong id="modeStatus">-</strong></span>
+      <span class="tag">上次更新: <strong id="lastUpdated">-</strong></span>
+      <label class="toggle"><input type="checkbox" id="autoRefresh" checked /> 自动刷新</label>
+      <button type="button" class="secondary" id="manualRefresh">立即刷新</button>
+      <form method="post" action="/dashboard/logout" style="display:inline">
+        <button type="submit" class="secondary">退出登录</button>
+      </form>
+    </div>
+    <p id="statusMessage" class="message" role="status"></p>
+  </header>
+
+  <section class="grid" id="summaryCards">
+    <div class="card">
+      <h2>总请求数</h2>
+      <div class="stat" id="totalRequests">0</div>
+      <div class="stat-label">Total Requests</div>
+    </div>
+    <div class="card">
+      <h2>成功请求</h2>
+      <div class="stat status-success" id="successRequests">0</div>
+      <div class="stat-label">Successful</div>
+    </div>
+    <div class="card">
+      <h2>失败请求</h2>
+      <div class="stat status-failure" id="failedRequests">0</div>
+      <div class="stat-label">Failed</div>
+    </div>
+    <div class="card">
+      <h2>平均响应时间 (ms)</h2>
+      <div class="stat" id="avgResponse">0</div>
+      <div class="stat-label">Average Response Time</div>
+    </div>
+  </section>
+
+  <section class="card" style="margin-top:24px;">
+    <div class="section-title">
+      <h2>Backup Token 管理</h2>
+    </div>
+    <p id="tokenInfo" class="stat-label">当前共有 <span id="tokenCount">0</span> 个可用 token。</p>
+    <div class="token-form">
+      <input type="text" id="newToken" placeholder="输入新的 backup token" />
+      <button type="button" class="primary" id="addTokenBtn">添加 Token</button>
+    </div>
+    <p id="tokenMessage" class="message" role="status"></p>
+    <div class="token-table-wrapper">
+      <table>
+        <thead>
+          <tr>
+            <th>Token</th>
+            <th>成功次数</th>
+            <th>失败次数</th>
+            <th>操作</th>
+          </tr>
+        </thead>
+        <tbody id="tokenTableBody"></tbody>
+      </table>
+    </div>
+  </section>
+
+  <section class="card" style="margin-top:24px;">
+    <div class="section-title">
+      <h2>最近请求 (最多 100 条)</h2>
+      <span class="stat-label" id="requestCount">0 条记录</span>
+    </div>
+    <div style="overflow-x:auto;">
+      <table>
+        <thead>
+          <tr>
+            <th>时间</th>
+            <th>方法</th>
+            <th>路径</th>
+            <th>状态码</th>
+            <th>耗时 (ms)</th>
+            <th>结果</th>
+            <th>客户端 IP</th>
+            <th>Token</th>
+          </tr>
+        </thead>
+        <tbody id="requestTableBody"></tbody>
+      </table>
+    </div>
+  </section>
+
+  <script>
+    const autoRefreshCheckbox = document.getElementById('autoRefresh');
+    const manualRefreshBtn = document.getElementById('manualRefresh');
+    const statusMessage = document.getElementById('statusMessage');
+    const tokenTableBody = document.getElementById('tokenTableBody');
+    const tokenMessage = document.getElementById('tokenMessage');
+    const newTokenInput = document.getElementById('newToken');
+    const addTokenBtn = document.getElementById('addTokenBtn');
+    let refreshTimer = null;
+
+    function formatTime(ts) {
+      try {
+        return new Date(ts).toLocaleString();
+      } catch {
+        return ts;
+      }
+    }
+
+    function setStatus(message, type = '') {
+      statusMessage.textContent = message;
+      statusMessage.className = 'message ' + type;
+    }
+
+    async function fetchData() {
+      try {
+        const response = await fetch('/dashboard/api/data', { credentials: 'same-origin' });
+        if (!response.ok) {
+          throw new Error('无法获取监控数据');
+        }
+        const data = await response.json();
+        updateSummary(data.summary);
+        updateMode(data.anonymousMode);
+        updateTokens(data.backupTokens);
+        updateRequests(data.recentRequests);
+        document.getElementById('lastUpdated').textContent = formatTime(data.updatedAt);
+        setStatus('数据已更新。', 'success');
+      } catch (error) {
+        console.error(error);
+        setStatus(error.message, 'error');
+      }
+    }
+
+    function updateSummary(summary) {
+      document.getElementById('totalRequests').textContent = summary.totalRequests;
+      document.getElementById('successRequests').textContent = summary.successfulRequests;
+      document.getElementById('failedRequests').textContent = summary.failedRequests;
+      document.getElementById('avgResponse').textContent = summary.averageResponseTime;
+    }
+
+    function updateMode(isAnonymous) {
+      document.getElementById('modeStatus').textContent = isAnonymous ? '开启' : '关闭';
+    }
+
+    function updateTokens(tokens) {
+      tokenTableBody.innerHTML = '';
+      document.getElementById('tokenCount').textContent = tokens.length;
+      if (tokens.length === 0) {
+        const row = document.createElement('tr');
+        const cell = document.createElement('td');
+        cell.colSpan = 4;
+        cell.textContent = '暂无配置的 backup token';
+        cell.style.textAlign = 'center';
+        row.appendChild(cell);
+        tokenTableBody.appendChild(row);
+        return;
+      }
+      for (const token of tokens) {
+        const row = document.createElement('tr');
+        row.innerHTML = `
+          <td style="word-break: break-all;">${token.token}</td>
+          <td class="status-success">${token.success}</td>
+          <td class="status-failure">${token.failure}</td>
+          <td><button type="button" class="secondary" data-token="${encodeURIComponent(token.token)}">删除</button></td>
+        `;
+        tokenTableBody.appendChild(row);
+      }
+    }
+
+    function updateRequests(requests) {
+      const requestTableBody = document.getElementById('requestTableBody');
+      requestTableBody.innerHTML = '';
+      document.getElementById('requestCount').textContent = `${requests.length} 条记录`;
+      if (requests.length === 0) {
+        const row = document.createElement('tr');
+        const cell = document.createElement('td');
+        cell.colSpan = 8;
+        cell.textContent = '暂无请求记录';
+        cell.style.textAlign = 'center';
+        row.appendChild(cell);
+        requestTableBody.appendChild(row);
+        return;
+      }
+      for (const req of requests) {
+        const row = document.createElement('tr');
+        const statusClass = req.success ? 'status-success' : 'status-failure';
+        row.innerHTML = `
+          <td>${formatTime(req.timestamp)}</td>
+          <td>${req.method}</td>
+          <td>${req.path}</td>
+          <td class="${statusClass}">${req.status}</td>
+          <td>${req.durationMs}</td>
+          <td class="${statusClass}">${req.success ? '成功' : '失败'}</td>
+          <td>${req.clientIp}</td>
+          <td>${req.tokenDisplay}</td>
+        `;
+        requestTableBody.appendChild(row);
+      }
+    }
+
+    function startAutoRefresh() {
+      if (refreshTimer) return;
+      refreshTimer = setInterval(fetchData, 5000);
+    }
+
+    function stopAutoRefresh() {
+      if (refreshTimer) {
+        clearInterval(refreshTimer);
+        refreshTimer = null;
+      }
+    }
+
+    autoRefreshCheckbox.addEventListener('change', () => {
+      if (autoRefreshCheckbox.checked) {
+        startAutoRefresh();
+        setStatus('自动刷新已开启。');
+      } else {
+        stopAutoRefresh();
+        setStatus('自动刷新已关闭。', 'warning');
+      }
+    });
+
+    manualRefreshBtn.addEventListener('click', () => {
+      fetchData();
+    });
+
+    addTokenBtn.addEventListener('click', async () => {
+      const token = newTokenInput.value.trim();
+      if (!token) {
+        tokenMessage.textContent = '请输入有效的 token。';
+        tokenMessage.className = 'message error';
+        return;
+      }
+      try {
+        const res = await fetch('/dashboard/api/tokens', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          credentials: 'same-origin',
+          body: JSON.stringify({ token })
+        });
+        if (!res.ok) {
+          const err = await res.json().catch(() => ({ error: '添加失败' }));
+          throw new Error(err.error || '添加失败');
+        }
+        newTokenInput.value = '';
+        tokenMessage.textContent = 'Token 添加成功。';
+        tokenMessage.className = 'message success';
+        const data = await res.json();
+        updateTokens(data.tokens);
+        setStatus('Token 列表已更新。');
+      } catch (error) {
+        tokenMessage.textContent = error.message;
+        tokenMessage.className = 'message error';
+      }
+    });
+
+    tokenTableBody.addEventListener('click', async (event) => {
+      const target = event.target;
+      if (!(target instanceof HTMLElement)) return;
+      const encoded = target.dataset.token;
+      if (!encoded) return;
+      if (!confirm('确定要删除该 token 吗？')) return;
+      try {
+        const res = await fetch('/dashboard/api/tokens', {
+          method: 'DELETE',
+          headers: { 'Content-Type': 'application/json' },
+          credentials: 'same-origin',
+          body: JSON.stringify({ token: decodeURIComponent(encoded) })
+        });
+        if (!res.ok) {
+          const err = await res.json().catch(() => ({ error: '删除失败' }));
+          throw new Error(err.error || '删除失败');
+        }
+        const data = await res.json();
+        updateTokens(data.tokens);
+        tokenMessage.textContent = 'Token 删除成功。';
+        tokenMessage.className = 'message success';
+        setStatus('Token 列表已更新。');
+      } catch (error) {
+        tokenMessage.textContent = error.message;
+        tokenMessage.className = 'message error';
+      }
+    });
+
+    fetchData();
+    startAutoRefresh();
+  </script>
+</body>
+</html>`;
+
+export const dashboardRouter = new Router();
+
+dashboardRouter.get("/dashboard", async (ctx) => {
+  const authed = await ensureSession(ctx);
+  ctx.response.headers.set("Content-Type", "text/html; charset=utf-8");
+  if (!authed) {
+    ctx.response.body = renderLoginPage();
+    return;
+  }
+  ctx.response.body = dashboardPage;
+});
+
+dashboardRouter.post("/dashboard/login", async (ctx) => {
+  const body = ctx.request.body({ type: "form" });
+  const form = await body.value;
+  const password = form.get("password") ?? "";
+  if (password === config.AUTH_TOKEN) {
+    const sessionId = createSession();
+    await ctx.cookies.set(SESSION_COOKIE, sessionId, {
+      httpOnly: true,
+      sameSite: "Strict",
+      maxAge: SESSION_DURATION / 1000,
+    });
+    ctx.response.redirect("/dashboard");
+    return;
+  }
+
+  ctx.response.status = 401;
+  ctx.response.headers.set("Content-Type", "text/html; charset=utf-8");
+  ctx.response.body = renderLoginPage("密码错误，请重试。");
+});
+
+dashboardRouter.post("/dashboard/logout", async (ctx) => {
+  const sessionId = await ctx.cookies.get(SESSION_COOKIE);
+  if (sessionId) {
+    sessions.delete(sessionId);
+  }
+  await ctx.cookies.delete(SESSION_COOKIE);
+  ctx.response.redirect("/dashboard");
+});
+
+dashboardRouter.use("/dashboard/api", async (ctx, next) => {
+  const authed = await ensureSession(ctx);
+  if (!authed) {
+    ctx.response.status = 401;
+    ctx.response.headers.set("Content-Type", "application/json");
+    ctx.response.body = { error: "Unauthorized" };
+    return;
+  }
+  await next();
+});
+
+dashboardRouter.get("/dashboard/api/data", (ctx) => {
+  const summary = metricsManager.getSummary();
+  const requests = metricsManager.getRecentRequests();
+  ctx.response.headers.set("Content-Type", "application/json");
+  ctx.response.body = {
+    summary,
+    anonymousMode: config.ANONYMOUS_MODE,
+    backupTokens: backupTokenManager.getStatus(),
+    recentRequests: requests,
+    updatedAt: new Date().toISOString(),
+  };
+});
+
+dashboardRouter.post("/dashboard/api/tokens", async (ctx) => {
+  try {
+    const body = await ctx.request.body({ type: "json" }).value;
+    const token = (body?.token ?? "").trim();
+    if (!token) {
+      ctx.response.status = 400;
+      ctx.response.headers.set("Content-Type", "application/json");
+      ctx.response.body = { error: "Token 不能为空" };
+      return;
+    }
+    const added = backupTokenManager.addToken(token);
+    if (!added) {
+      ctx.response.status = 409;
+      ctx.response.headers.set("Content-Type", "application/json");
+      ctx.response.body = { error: "Token 已存在或无效" };
+      return;
+    }
+    ctx.response.headers.set("Content-Type", "application/json");
+    ctx.response.body = { success: true, tokens: backupTokenManager.getStatus() };
+  } catch (error) {
+    ctx.response.status = 400;
+    ctx.response.headers.set("Content-Type", "application/json");
+    ctx.response.body = { error: `无法解析请求: ${error}` };
+  }
+});
+
+dashboardRouter.delete("/dashboard/api/tokens", async (ctx) => {
+  try {
+    const body = await ctx.request.body({ type: "json" }).value;
+    const token = (body?.token ?? "").trim();
+    if (!token) {
+      ctx.response.status = 400;
+      ctx.response.headers.set("Content-Type", "application/json");
+      ctx.response.body = { error: "Token 不能为空" };
+      return;
+    }
+    const removed = backupTokenManager.removeToken(token);
+    if (!removed) {
+      ctx.response.status = 404;
+      ctx.response.headers.set("Content-Type", "application/json");
+      ctx.response.body = { error: "未找到指定 token" };
+      return;
+    }
+    ctx.response.headers.set("Content-Type", "application/json");
+    ctx.response.body = { success: true, tokens: backupTokenManager.getStatus() };
+  } catch (error) {
+    ctx.response.status = 400;
+    ctx.response.headers.set("Content-Type", "application/json");
+    ctx.response.body = { error: `无法解析请求: ${error}` };
+  }
+});

--- a/main.ts
+++ b/main.ts
@@ -7,6 +7,7 @@ import { Application, Router } from "oak/mod.ts";
 import { cors } from "jsr:@momiji/cors@^1.0.0";
 import { config } from "./app/core/config.ts";
 import { openaiRouter } from "./app/core/openai.ts";
+import { dashboardRouter } from "./app/dashboard/router.ts";
 
 // 创建 Oak 应用
 const app = new Application();
@@ -25,6 +26,10 @@ const router = new Router();
 // 引入 OpenAI API 路由
 router.use("/v1", openaiRouter.routes());
 router.use("/v1", openaiRouter.allowedMethods());
+
+// 引入 Dashboard 路由
+router.use(dashboardRouter.routes());
+router.use(dashboardRouter.allowedMethods());
 
 // 根路径端点
 router.get("/", (ctx) => {


### PR DESCRIPTION
## Summary
- support comma-delimited BACKUP_TOKEN values with round-robin usage and track token-level success metrics
- add a secured dashboard at /dashboard that surfaces request analytics, recent activity, and backup token management
- provide a Dockerfile and README updates for container deployments

## Testing
- `deno test` *(fails: deno executable not available in container)*

------
https://chatgpt.com/codex/tasks/task_b_68e1383fffac8320883c7e7c70bed6af